### PR TITLE
Remove Sinatra and the web process

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ ruby "2.2.2"
 gem "rake"
 gem "resque"
 gem "scss-lint", "0.34.0"
-gem "sinatra"
 
 group :test, :development do
   gem "byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,4 +57,6 @@ DEPENDENCIES
   resque
   rspec
   scss-lint (= 0.34.0)
-  sinatra
+
+BUNDLED WITH
+   1.10.5

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,1 @@
-web: bundle exec ruby app.rb -p $PORT
 resque: TERM_CHILD=1 RESQUE_TERM_TIMEOUT=7 QUEUES=scss_review bundle exec rake jobs:work

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 SCSS review service for Hound.
 
-The service consists of a simple Sinatra app and job class that uses Redis as a
-queue to coordinate work with Hound.
+The service consists of a simple job class that uses Redis as a queue to
+coordinate work with Hound.
 
 ## Getting Started
 

--- a/app.rb
+++ b/app.rb
@@ -1,5 +1,0 @@
-require "sinatra"
-
-def app
-  Sinatra::Application
-end


### PR DESCRIPTION
The app doesn't use the web process, but I think it was there because
the old, free dyno structure didn't allow for workers without a web
process. Production is now on a Professional worker dyno with no web
dyno, and staging is on a hobby worker dyno with no web dyno. It seems
like bumping up to any of the free tiers removes the web process
restriction and we can now get rid of it.