### PR TITLE
Exclude `vendor/**/*` from the paths that should be linted

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1,4 +1,5 @@
 scss_files: "**/*.scss"
+exclude: "vendor/**/*"
 linters:
   BangFormat:
     enabled: true


### PR DESCRIPTION
In a Rails app (and pretty much everywhere) the `vendor/` directory
could contain some `.scss` files that you don't want to be linted.