### PR TITLE
Monkey patch SCSS-Lint to match excluded files

### DIFF
--- a/lib/ext/scss_lint/config.rb
+++ b/lib/ext/scss_lint/config.rb
@@ -1,0 +1,12 @@
+# Patch SCSSLint::Config to expand file_path
+# to the same directory as the config file,
+# which is a Tempfile itself.
+module SCSSLint
+  class Config
+    def excluded_file?(file_path)
+      @options.fetch("exclude", []).any? do |exclusion_glob|
+        File.fnmatch(exclusion_glob, file_path)
+      end
+    end
+  end
+end

--- a/lib/jobs/scss_review_job.rb
+++ b/lib/jobs/scss_review_job.rb
@@ -1,6 +1,7 @@
 require "resque"
 require "scss_lint"
 
+require "ext/scss_lint/config"
 require "jobs/completed_file_review_job"
 require "config_options"
 

--- a/spec/jobs/scss_review_job_spec.rb
+++ b/spec/jobs/scss_review_job_spec.rb
@@ -69,7 +69,7 @@ linters:
           "content" => ".a { display: 'none'; }\n",
           "config" => <<-CONFIG
 exclude:
-  - "**/test.scss"
+  - "test.scss"
           CONFIG
         )
 
@@ -89,20 +89,20 @@ exclude:
         allow(Resque).to receive("enqueue")
 
         ScssReviewJob.perform(
-          "filename" => "test.scss",
+          "filename" => "app/assets/test.scss",
           "commit_sha" => "123abc",
           "pull_request_number" => "123",
           "patch" => "test",
           "content" => ".a { display: 'none'; }\n",
           "config" => <<-CONFIG
 exclude:
-  "**/test.scss"
+  "app/assets/*"
           CONFIG
         )
 
         expect(Resque).to have_received("enqueue").with(
           CompletedFileReviewJob,
-          filename: "test.scss",
+          filename: "app/assets/test.scss",
           commit_sha: "123abc",
           pull_request_number: "123",
           patch: "test",


### PR DESCRIPTION
Why:

* `scss-lint` assumes files are stored on a disk,
  and it expands paths before matching them for exclusion checks.
* Hound doesn't store files to disk,
  thus we have to make an assumption about the root path.
* This fixes a current issue where SCSS files aren't excluded.

Fixes https://github.com/thoughtbot/hound/issues/879