### PR TITLE
Upgrade `scss_lint`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ ruby "2.2.2"
 
 gem "rake"
 gem "resque"
-gem "scss-lint", "0.34.0"
+gem "scss_lint", "0.42.2"
 
 group :test, :development do
   gem "byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,10 +36,10 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.2.0)
     rspec-support (3.2.2)
-    sass (3.4.13)
-    scss-lint (0.34.0)
+    sass (3.4.19)
+    scss_lint (0.42.2)
       rainbow (~> 2.0)
-      sass (~> 3.4.1)
+      sass (~> 3.4.15)
     sinatra (1.4.5)
       rack (~> 1.4)
       rack-protection (~> 1.4)
@@ -56,7 +56,7 @@ DEPENDENCIES
   rake
   resque
   rspec
-  scss-lint (= 0.34.0)
+  scss_lint (= 0.42.2)
 
 BUNDLED WITH
-   1.10.5
+   1.10.6

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,145 +1,234 @@
+# Default application configuration that all configurations inherit from.
+
 scss_files: "**/*.scss"
+plugin_directories: ['.scss-linters']
+
+# List of gem names to load custom linters from (make sure they are already
+# installed)
+plugin_gems: []
+
 linters:
   BangFormat:
     enabled: true
     space_before_bang: true
     space_after_bang: false
-  BorderZero:
+
+  BemDepth:
     enabled: false
-    convention: zero
+    max_elements: 1
+
+  BorderZero:
+    enabled: true
+    convention: zero # or `none`
+
   ColorKeyword:
     enabled: true
-    severity: warning
+
   ColorVariable:
     enabled: true
+
   Comment:
     enabled: true
+
   DebugStatement:
     enabled: true
+
   DeclarationOrder:
     enabled: true
+
+  DisableLinterReason:
+    enabled: false
+
   DuplicateProperty:
     enabled: true
+
   ElsePlacement:
     enabled: true
-    style: same_line
+    style: same_line # or 'new_line'
+
   EmptyLineBetweenBlocks:
     enabled: true
     ignore_single_line_blocks: true
+
   EmptyRule:
     enabled: true
+
+  ExtendDirective:
+    enabled: false
+
   FinalNewline:
     enabled: true
     present: true
+
   HexLength:
     enabled: false
-    style: short
+    style: short # or 'long'
+
   HexNotation:
     enabled: true
-    style: lowercase
+    style: lowercase # or 'uppercase'
+
   HexValidation:
     enabled: true
+
   IdSelector:
     enabled: true
+
   ImportantRule:
     enabled: true
+
   ImportPath:
     enabled: true
     leading_underscore: false
     filename_extension: false
+
   Indentation:
     enabled: true
     allow_non_nested_indentation: false
-    character: space
+    character: space # or 'tab'
     width: 2
+
   LeadingZero:
     enabled: true
-    style: include_zero
+    style: include_zero # or 'exclude_zero'
+
   MergeableSelector:
     enabled: true
     force_nesting: true
+
   NameFormat:
     enabled: true
     allow_leading_underscore: true
-    convention: hyphenated_lowercase
+    convention: hyphenated_lowercase # or 'camel_case', or 'snake_case', or a regex pattern
+
   NestingDepth:
     enabled: true
     max_depth: 4
-    severity: warning
+    ignore_parent_selectors: false
+
   PlaceholderInExtend:
     enabled: false
+
   PropertyCount:
     enabled: true
     include_nested: false
     max_properties: 10
+
   PropertySortOrder:
     enabled: true
     ignore_unspecified: false
-    severity: warning
+    min_properties: 2
     separate_groups: false
+
   PropertySpelling:
     enabled: true
     extra_properties: []
+
+  PropertyUnits:
+    enabled: true
+    global: [
+      'ch', 'em', 'ex', 'rem',                 # Font-relative lengths
+      'cm', 'in', 'mm', 'pc', 'pt', 'px', 'q', # Absolute lengths
+      'vh', 'vw', 'vmin', 'vmax',              # Viewport-percentage lengths
+      'deg', 'grad', 'rad', 'turn',            # Angle
+      'ms', 's',                               # Duration
+      'Hz', 'kHz',                             # Frequency
+      'dpi', 'dpcm', 'dppx',                   # Resolution
+      '%']                                     # Other
+    properties: {}
+
   QualifyingElement:
     enabled: true
     allow_element_with_attribute: false
     allow_element_with_class: false
     allow_element_with_id: false
-    severity: warning
+
   SelectorDepth:
     enabled: true
     max_depth: 2
-    severity: warning
+
   SelectorFormat:
     enabled: true
-    convention: hyphenated_lowercase
+    convention: hyphenated_lowercase # or 'strict_BEM', or 'hyphenated_BEM', or 'snake_case', or 'camel_case', or a regex pattern
+
   Shorthand:
     enabled: true
-    severity: warning
+    allowed_shorthands: [1, 2, 3]
+
   SingleLinePerProperty:
     enabled: true
     allow_single_line_rule_sets: true
+
   SingleLinePerSelector:
     enabled: true
+
   SpaceAfterComma:
     enabled: true
+    style: one_space # or 'no_space', or 'at_least_one_space'
+
   SpaceAfterPropertyColon:
     enabled: true
-    style: one_space
+    style: one_space # or 'no_space', or 'at_least_one_space', or 'aligned'
+
   SpaceAfterPropertyName:
     enabled: true
+
+  SpaceAfterVariableName:
+    enabled: true
+
+  SpaceAroundOperator:
+    enabled: true
+    style: one_space # or 'no_space'
+
   SpaceBeforeBrace:
     enabled: true
-    style: space
+    style: space # or 'new_line'
     allow_single_line_padding: false
+
   SpaceBetweenParens:
     enabled: true
     spaces: 0
+
   StringQuotes:
     enabled: true
-    style: double_quotes
+    style: double_quotes # or single_quotes
+
   TrailingSemicolon:
     enabled: true
+
+  TrailingWhitespace:
+    enabled: true
+
   TrailingZero:
     enabled: false
+
+  TransitionAll:
+    enabled: false
+
   UnnecessaryMantissa:
     enabled: true
+
   UnnecessaryParentReference:
     enabled: true
+
   UrlFormat:
     enabled: true
+
   UrlQuotes:
     enabled: true
+
   VariableForProperty:
     enabled: false
     properties: []
-  VendorPrefixes:
+
+  VendorPrefix:
     enabled: true
     identifier_list: bourbon
-    include: []
-    exclude: []
+    additional_identifiers: []
+    excluded_identifiers: []
+
   ZeroUnit:
     enabled: true
-    severity: warning
-  Compass::PropertyWithMixin:
+
+  Compass::*:
     enabled: false

--- a/spec/jobs/scss_review_job_spec.rb
+++ b/spec/jobs/scss_review_job_spec.rb
@@ -8,7 +8,7 @@ describe ScssReviewJob do
         allow(Resque).to receive("enqueue")
 
         ScssReviewJob.perform(
-          "filename" => "test.scss",
+          "filename" => "app/assets/stylsheets/test.scss",
           "commit_sha" => "123abc",
           "pull_request_number" => "123",
           "patch" => "test",
@@ -17,7 +17,7 @@ describe ScssReviewJob do
 
         expect(Resque).to have_received("enqueue").with(
           CompletedFileReviewJob,
-          filename: "test.scss",
+          filename: "app/assets/stylsheets/test.scss",
           commit_sha: "123abc",
           pull_request_number: "123",
           patch: "test",
@@ -33,7 +33,7 @@ describe ScssReviewJob do
         allow(Resque).to receive("enqueue")
 
         ScssReviewJob.perform(
-          "filename" => "test.scss",
+          "filename" => "app/assets/stylsheets/test.scss",
           "commit_sha" => "123abc",
           "pull_request_number" => "123",
           "patch" => "test",
@@ -48,7 +48,7 @@ linters:
 
         expect(Resque).to have_received("enqueue").with(
           CompletedFileReviewJob,
-          filename: "test.scss",
+          filename: "app/assets/stylsheets/test.scss",
           commit_sha: "123abc",
           pull_request_number: "123",
           patch: "test",
@@ -62,20 +62,20 @@ linters:
         allow(Resque).to receive("enqueue")
 
         ScssReviewJob.perform(
-          "filename" => "test.scss",
+          "filename" => "app/assets/stylesheets/test.scss",
           "commit_sha" => "123abc",
           "pull_request_number" => "123",
           "patch" => "test",
           "content" => ".a { display: 'none'; }\n",
           "config" => <<-CONFIG
 exclude:
-  - "test.scss"
+  - "app/assets/stylesheets/test.scss"
           CONFIG
         )
 
         expect(Resque).to have_received("enqueue").with(
           CompletedFileReviewJob,
-          filename: "test.scss",
+          filename: "app/assets/stylesheets/test.scss",
           commit_sha: "123abc",
           pull_request_number: "123",
           patch: "test",
@@ -89,7 +89,7 @@ exclude:
         allow(Resque).to receive("enqueue")
 
         ScssReviewJob.perform(
-          "filename" => "app/assets/test.scss",
+          "filename" => "app/assets/stylsheets/test.scss",
           "commit_sha" => "123abc",
           "pull_request_number" => "123",
           "patch" => "test",
@@ -102,7 +102,7 @@ exclude:
 
         expect(Resque).to have_received("enqueue").with(
           CompletedFileReviewJob,
-          filename: "app/assets/test.scss",
+          filename: "app/assets/stylsheets/test.scss",
           commit_sha: "123abc",
           pull_request_number: "123",
           patch: "test",


### PR DESCRIPTION
Changes:

- Use a tempfile instead of the raw content.
  `scss-lint` removed support for linting the content of a file, and now
  only lints actual files.
  To remedy that fact, we create a tempfile with the content of the file the
  service is linting.
- Upgrade scss-lint's default configuration.
  - Tweak the config to have the same opinionated defaults as before.
  - Allow all new rules.
  - Remove severity level

https://trello.com/c/tltqHIJ6