### PR TITLE
Update SCSS-Lint to v0.43.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ ruby "2.2.2"
 
 gem "rake"
 gem "resque"
-gem "scss_lint", "0.42.2"
+gem "scss_lint", "0.43.2"
 
 group :test, :development do
   gem "byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,8 +36,8 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.2.0)
     rspec-support (3.2.2)
-    sass (3.4.19)
-    scss_lint (0.42.2)
+    sass (3.4.20)
+    scss_lint (0.43.2)
       rainbow (~> 2.0)
       sass (~> 3.4.15)
     sinatra (1.4.5)
@@ -56,7 +56,7 @@ DEPENDENCIES
   rake
   resque
   rspec
-  scss_lint (= 0.42.2)
+  scss_lint (= 0.43.2)
 
 BUNDLED WITH
    1.10.6

--- a/config/default.yml
+++ b/config/default.yml
@@ -21,6 +21,9 @@ linters:
     enabled: true
     convention: zero # or `none`
 
+  ChainedClasses:
+    enabled: false
+
   ColorKeyword:
     enabled: true
 
@@ -29,6 +32,7 @@ linters:
 
   Comment:
     enabled: true
+    style: silent
 
   DebugStatement:
     enabled: true
@@ -123,6 +127,7 @@ linters:
   PropertySpelling:
     enabled: true
     extra_properties: []
+    disabled_properties: []
 
   PropertyUnits:
     enabled: true
@@ -136,6 +141,9 @@ linters:
       'dpi', 'dpcm', 'dppx',                   # Resolution
       '%']                                     # Other
     properties: {}
+
+  PseudoElement:
+    enabled: true
 
   QualifyingElement:
     enabled: true
@@ -178,7 +186,7 @@ linters:
 
   SpaceAroundOperator:
     enabled: true
-    style: one_space # or 'no_space'
+    style: one_space # or 'at_least_one_space', or 'no_space'
 
   SpaceBeforeBrace:
     enabled: true
@@ -223,7 +231,7 @@ linters:
 
   VendorPrefix:
     enabled: true
-    identifier_list: bourbon
+    identifier_list: base
     additional_identifiers: []
     excluded_identifiers: []
 

--- a/lib/jobs/scss_review_job.rb
+++ b/lib/jobs/scss_review_job.rb
@@ -26,7 +26,12 @@ class ScssReviewJob
       scss_lint_runner = SCSSLint::Runner.new(scss_lint_config)
 
       tempfile_from(attributes) do |tempfile|
-        scss_lint_runner.run([tempfile])
+        scss_lint_runner.run(
+          [
+            file: tempfile,
+            path: attributes.fetch("filename"),
+          ],
+        )
       end
 
       violations = scss_lint_runner.lints.map do |lint|


### PR DESCRIPTION
I pulled the configuration straight from SCSS-Lint’s, found here: https://github.com/brigade/scss-lint/blob/master/config/default.yml