### PR TITLE
Report invalid configuration files in Hound proper

### DIFF
--- a/lib/config_options.rb
+++ b/lib/config_options.rb
@@ -5,7 +5,16 @@ class ConfigOptions
   DEFAULT_CONFIG_FILE = "config/default.yml"
 
   def initialize(config)
-    @custom_options = YAML.load(config || "")
+    @valid = true
+    begin
+      @custom_options = YAML.safe_load(config || "", [Regexp])
+    rescue Psych::Exception
+      @valid = false
+    end
+  end
+
+  def valid?
+    valid
   end
 
   def to_hash
@@ -14,7 +23,7 @@ class ConfigOptions
 
   private
 
-  attr_reader :custom_options
+  attr_reader :custom_options, :valid
 
   def merge(base_options, options)
     merged_options = SCSSLint::Config.send(

--- a/lib/jobs/report_invalid_config_job.rb
+++ b/lib/jobs/report_invalid_config_job.rb
@@ -1,0 +1,3 @@
+class ReportInvalidConfigJob
+  @queue = :high
+end

--- a/spec/config_options_spec.rb
+++ b/spec/config_options_spec.rb
@@ -2,6 +2,24 @@ require "spec_helper"
 require "config_options"
 
 describe ConfigOptions do
+  describe "#valid?" do
+    context "when given a valid config" do
+      it "returns true" do
+        config_options = ConfigOptions.new("")
+
+        expect(config_options.valid?).to eq true
+      end
+    end
+
+    context "when given an invalid config" do
+      it "returns false" do
+        config_options = ConfigOptions.new("--- !ruby/object:FooBar {}")
+
+        expect(config_options.valid?).to eq false
+      end
+    end
+  end
+
   describe "#to_hash" do
     it "returns merged config options as a hash" do
       config_options = ConfigOptions.new(<<-CONFIG)


### PR DESCRIPTION
When an invalid configuration file is parsed, it should be marked as
invalid to let the end user know.

This is done by enqueuing the `ReportInvalidConfigJob` in Hound proper,
which will update the build status to mark the configuration file as
invalid.

https://trello.com/c/42U5K0Bs