### PR TITLE
Extract service object out of `ScssReviewJob`

### DIFF
--- a/lib/jobs/scss_review_job.rb
+++ b/lib/jobs/scss_review_job.rb
@@ -1,90 +1,16 @@
-require "tempfile"
-require "resque"
-require "scss_lint"
-
-require "ext/scss_lint/config"
-require "jobs/completed_file_review_job"
-require "jobs/report_invalid_config_job"
-require "config_options"
+require "review"
 
 class ScssReviewJob
-  LINTER_NAME = "scss"
-
   @queue = :scss_review
 
+  # The following parameters are required for this job to run.
+  # - filename
+  # - commit_sha
+  # - pull_request_number (pass-through)
+  # - patch (pass-through)
+  # - content
+  # - config
   def self.perform(attributes)
-    # filename
-    # commit_sha
-    # pull_request_number (pass-through)
-    # patch (pass-through)
-    # content
-    # config
-
-    config_options = ConfigOptions.new(attributes["config"])
-
-    if config_options.valid?
-      review_file(config_options, attributes)
-    else
-      report_invalid_config(attributes)
-    end
+    Review.run(attributes)
   end
-
-  def self.review_file(config_options, attributes)
-    scss_lint_config = SCSSLint::Config.new(config_options.to_hash)
-    filename = attributes.fetch("filename")
-    violations = []
-
-    unless scss_lint_config.excluded_file?(filename)
-      scss_lint_runner = SCSSLint::Runner.new(scss_lint_config)
-
-      tempfile_from(attributes) do |tempfile|
-        scss_lint_runner.run(
-          [
-            file: tempfile,
-            path: attributes.fetch("filename"),
-          ],
-        )
-      end
-
-      violations = scss_lint_runner.lints.map do |lint|
-        { line: lint.location.line, message: lint.description }
-      end
-    end
-
-    complete_file_review(violations, attributes)
-  end
-  private_class_method :review_file
-
-  def self.tempfile_from(attributes)
-    filename = File.basename(attributes.fetch("filename"))
-    Tempfile.create(filename) do |file|
-      file.write(attributes.fetch("content"))
-      file.rewind
-
-      yield(file)
-    end
-  end
-  private_class_method :tempfile_from
-
-  def self.complete_file_review(violations, attributes)
-    Resque.enqueue(
-      CompletedFileReviewJob,
-      filename: attributes.fetch("filename"),
-      commit_sha: attributes.fetch("commit_sha"),
-      pull_request_number: attributes.fetch("pull_request_number"),
-      patch: attributes.fetch("patch"),
-      violations: violations,
-    )
-  end
-  private_class_method :complete_file_review
-
-  def self.report_invalid_config(attributes)
-    Resque.enqueue(
-      ReportInvalidConfigJob,
-      pull_request_number: attributes.fetch("pull_request_number"),
-      commit_sha: attributes.fetch("commit_sha"),
-      linter_name: LINTER_NAME,
-    )
-  end
-  private_class_method :report_invalid_config
 end

--- a/lib/review.rb
+++ b/lib/review.rb
@@ -1,0 +1,88 @@
+require "resque"
+require "scss_lint"
+require "ext/scss_lint/config.rb"
+require "config_options"
+require "jobs/completed_file_review_job"
+require "jobs/report_invalid_config_job"
+
+class Review
+  COMMIT_SHA = "commit_sha".freeze
+  CONFIG = "config".freeze
+  CONTENT = "content".freeze
+  DEFAULT_VIOLATIONS = [].freeze
+  FILENAME = "filename".freeze
+  LINTER_NAME = "scss".freeze
+  PATCH = "patch".freeze
+  PULL_REQUEST_NUMBER = "pull_request_number".freeze
+
+  def self.run(attributes)
+    new(attributes).run
+  end
+
+  def initialize(attributes)
+    @attributes = attributes
+    @config_options = ConfigOptions.new(attributes[CONFIG])
+  end
+
+  def run
+    if config_options.valid?
+      violations = review_file
+      complete_file_review(violations)
+    else
+      report_invalid_config
+    end
+  end
+
+  private
+
+  attr_reader :config_options, :attributes
+
+  def report_invalid_config
+    Resque.enqueue(
+      ReportInvalidConfigJob,
+      pull_request_number: attributes.fetch(PULL_REQUEST_NUMBER),
+      commit_sha: attributes.fetch(COMMIT_SHA),
+      linter_name: LINTER_NAME,
+    )
+  end
+
+  def review_file
+    scss_lint_config = SCSSLint::Config.new(config_options.to_hash)
+    filename = attributes.fetch(FILENAME)
+
+    if !scss_lint_config.excluded_file?(filename)
+      scss_lint_runner = SCSSLint::Runner.new(scss_lint_config)
+
+      create_tempfile do |tempfile|
+        scss_lint_runner.run([file: tempfile, path: filename])
+      end
+
+      scss_lint_runner.lints.map do |lint|
+        { line: lint.location.line, message: lint.description }
+      end
+    else
+      DEFAULT_VIOLATIONS
+    end
+  end
+
+  def create_tempfile
+    filename = File.basename(attributes.fetch(FILENAME))
+    Tempfile.create(filename) do |file|
+      file.write(attributes.fetch(CONTENT))
+      file.rewind
+
+      yield(file)
+    end
+  end
+
+  def complete_file_review(violations)
+    Resque.enqueue(
+      CompletedFileReviewJob,
+      filename: attributes.fetch(FILENAME),
+      commit_sha: attributes.fetch(COMMIT_SHA),
+      pull_request_number: attributes.fetch(PULL_REQUEST_NUMBER),
+      patch: attributes.fetch(PATCH),
+      violations: violations,
+    )
+  end
+end

--- a/spec/config_options_spec.rb
+++ b/spec/config_options_spec.rb
@@ -22,10 +22,10 @@ describe ConfigOptions do
 
   describe "#to_hash" do
     it "returns merged config options as a hash" do
-      config_options = ConfigOptions.new(<<-CONFIG)
-linters:
-  BangFormat:
-    enabled: false
+      config_options = ConfigOptions.new(<<-CONFIG.strip_heredoc)
+        linters:
+          BangFormat:
+            enabled: false
       CONFIG
 
       options_hash = config_options.to_hash

--- a/spec/jobs/scss_review_job_spec.rb
+++ b/spec/jobs/scss_review_job_spec.rb
@@ -3,137 +3,20 @@ require "jobs/scss_review_job"
 
 describe ScssReviewJob do
   describe ".perform" do
-    context "when the configuration file is invalid" do
-      it "reports the configuration file as such to Hound proper" do
-        allow(Resque).to receive(:enqueue)
-        attributes = {
-          "filename" => "app/assets/stylsheets/test.scss",
-          "commit_sha" => "123abc",
-          "pull_request_number" => "123",
-          "patch" => "test",
-          "content" => ".a { display: 'none'; }\n",
-          "config" => "--- !ruby/object:Foo {}",
-        }
+    it "calls ScssReview" do
+      allow(Review).to receive(:run)
+      attributes = {
+        "filename" => "app/assets/stylsheets/test.scss",
+        "commit_sha" => "123abc",
+        "pull_request_number" => "123",
+        "patch" => "test",
+        "content" => ".a { display: 'none'; }\n",
+        "config" => "--- !ruby/object:Foo {}",
+      }
 
-        ScssReviewJob.perform(attributes)
+      ScssReviewJob.perform(attributes)
 
-        expect(Resque).to have_received(:enqueue).with(
-          ReportInvalidConfigJob,
-          pull_request_number: "123",
-          commit_sha: "123abc",
-          linter_name: ScssReviewJob::LINTER_NAME,
-        )
-        expect(Resque).not_to have_received(:enqueue).
-          with(CompletedFileReviewJob, anything)
-      end
-    end
-
-    context "when double quotes are preferred by default" do
-      it "enqueues review job with violations" do
-        allow(Resque).to receive("enqueue")
-
-        ScssReviewJob.perform(
-          "filename" => "app/assets/stylsheets/test.scss",
-          "commit_sha" => "123abc",
-          "pull_request_number" => "123",
-          "patch" => "test",
-          "content" => ".a { display: 'none'; }\n"
-        )
-
-        expect(Resque).to have_received("enqueue").with(
-          CompletedFileReviewJob,
-          filename: "app/assets/stylsheets/test.scss",
-          commit_sha: "123abc",
-          pull_request_number: "123",
-          patch: "test",
-          violations: [
-            { line: 1, message: "Prefer double-quoted strings" }
-          ]
-        )
-      end
-    end
-
-    context "when string quotes rule is disabled" do
-      it "enqueues review job without violations" do
-        allow(Resque).to receive("enqueue")
-
-        ScssReviewJob.perform(
-          "filename" => "app/assets/stylsheets/test.scss",
-          "commit_sha" => "123abc",
-          "pull_request_number" => "123",
-          "patch" => "test",
-          "content" => ".a { display: 'none'; }\n",
-          "config" => <<-CONFIG
-linters:
-  StringQuotes:
-    enabled: false
-    style: double_quotes
-          CONFIG
-        )
-
-        expect(Resque).to have_received("enqueue").with(
-          CompletedFileReviewJob,
-          filename: "app/assets/stylsheets/test.scss",
-          commit_sha: "123abc",
-          pull_request_number: "123",
-          patch: "test",
-          violations: []
-        )
-      end
-    end
-
-    context "when file with violations is excluded as an Array" do
-      it "enqueues review job without violations" do
-        allow(Resque).to receive("enqueue")
-
-        ScssReviewJob.perform(
-          "filename" => "app/assets/stylesheets/test.scss",
-          "commit_sha" => "123abc",
-          "pull_request_number" => "123",
-          "patch" => "test",
-          "content" => ".a { display: 'none'; }\n",
-          "config" => <<-CONFIG
-exclude:
-  - "app/assets/stylesheets/test.scss"
-          CONFIG
-        )
-
-        expect(Resque).to have_received("enqueue").with(
-          CompletedFileReviewJob,
-          filename: "app/assets/stylesheets/test.scss",
-          commit_sha: "123abc",
-          pull_request_number: "123",
-          patch: "test",
-          violations: []
-        )
-      end
-    end
-
-    context "when file with violations is excluded as a String" do
-      it "enqueues review job without violations" do
-        allow(Resque).to receive("enqueue")
-
-        ScssReviewJob.perform(
-          "filename" => "app/assets/stylsheets/test.scss",
-          "commit_sha" => "123abc",
-          "pull_request_number" => "123",
-          "patch" => "test",
-          "content" => ".a { display: 'none'; }\n",
-          "config" => <<-CONFIG
-exclude:
-  "app/assets/*"
-          CONFIG
-        )
-
-        expect(Resque).to have_received("enqueue").with(
-          CompletedFileReviewJob,
-          filename: "app/assets/stylsheets/test.scss",
-          commit_sha: "123abc",
-          pull_request_number: "123",
-          patch: "test",
-          violations: []
-        )
-      end
+      expect(Review).to have_received(:run).with(attributes)
     end
   end
 end

--- a/spec/review_spec.rb
+++ b/spec/review_spec.rb
@@ -1,0 +1,141 @@
+require "spec_helper"
+require "review"
+
+describe Review do
+  describe ".run" do
+    context "when the configuration file is invalid" do
+      it "reports the configuration file as such to Hound proper" do
+        allow(Resque).to receive(:enqueue)
+        attributes = {
+          "filename" => "app/assets/stylsheets/test.scss",
+          "commit_sha" => "123abc",
+          "pull_request_number" => "123",
+          "patch" => "test",
+          "content" => ".a { display: 'none'; }\n",
+          "config" => "--- !ruby/object:Foo {}",
+        }
+
+        Review.run(attributes)
+
+        expect(Resque).to have_received(:enqueue).with(
+          ReportInvalidConfigJob,
+          pull_request_number: "123",
+          commit_sha: "123abc",
+          linter_name: Review::LINTER_NAME,
+        )
+        expect(Resque).not_to have_received(:enqueue).
+          with(CompletedFileReviewJob, anything)
+      end
+    end
+
+    context "when double quotes are preferred by default" do
+      it "enqueues review job with violations" do
+        allow(Resque).to receive("enqueue")
+        attributes = {
+          "filename" => "app/assets/stylsheets/test.scss",
+          "commit_sha" => "123abc",
+          "pull_request_number" => "123",
+          "patch" => "test",
+          "content" => ".a { display: 'none'; }\n",
+        }
+
+        Review.run(attributes)
+
+        expect(Resque).to have_received("enqueue").with(
+          CompletedFileReviewJob,
+          filename: "app/assets/stylsheets/test.scss",
+          commit_sha: "123abc",
+          pull_request_number: "123",
+          patch: "test",
+          violations: [line: 1, message: "Prefer double-quoted strings"],
+        )
+      end
+    end
+
+    context "when string quotes rule is disabled" do
+      it "enqueues review job without violations" do
+        allow(Resque).to receive("enqueue")
+        attributes = {
+          "filename" => "app/assets/stylsheets/test.scss",
+          "commit_sha" => "123abc",
+          "pull_request_number" => "123",
+          "patch" => "test",
+          "content" => ".a { display: 'none'; }\n",
+          "config" => <<-CONFIG.strip_heredoc
+            linters:
+              StringQuotes:
+                enabled: false
+                style: double_quotes
+          CONFIG
+        }
+
+        Review.run(attributes)
+
+        expect(Resque).to have_received("enqueue").with(
+          CompletedFileReviewJob,
+          filename: "app/assets/stylsheets/test.scss",
+          commit_sha: "123abc",
+          pull_request_number: "123",
+          patch: "test",
+          violations: [],
+        )
+      end
+    end
+
+    context "when file with violations is excluded as an Array" do
+      it "enqueues review job without violations" do
+        allow(Resque).to receive("enqueue")
+        attributes = {
+          "filename" => "app/assets/stylesheets/test.scss",
+          "commit_sha" => "123abc",
+          "pull_request_number" => "123",
+          "patch" => "test",
+          "content" => ".a { display: 'none'; }\n",
+          "config" => <<-CONFIG.strip_heredoc
+            exclude:
+              - "app/assets/stylesheets/test.scss"
+          CONFIG
+        }
+
+        Review.run(attributes)
+
+        expect(Resque).to have_received("enqueue").with(
+          CompletedFileReviewJob,
+          filename: "app/assets/stylesheets/test.scss",
+          commit_sha: "123abc",
+          pull_request_number: "123",
+          patch: "test",
+          violations: [],
+        )
+      end
+    end
+
+    context "when file with violations is excluded as a String" do
+      it "enqueues review job without violations" do
+        allow(Resque).to receive("enqueue")
+        attributes = {
+          "filename" => "app/assets/stylsheets/test.scss",
+          "commit_sha" => "123abc",
+          "pull_request_number" => "123",
+          "patch" => "test",
+          "content" => ".a { display: 'none'; }\n",
+          "config" => <<-CONFIG.strip_heredoc
+            exclude:
+              "app/assets/*"
+          CONFIG
+        }
+
+        Review.run(attributes)
+
+        expect(Resque).to have_received("enqueue").with(
+          CompletedFileReviewJob,
+          filename: "app/assets/stylsheets/test.scss",
+          commit_sha: "123abc",
+          pull_request_number: "123",
+          patch: "test",
+          violations: [],
+        )
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 $: << File.expand_path(".")
 
+Dir["spec/support/**/*.rb"].each { |file| require file }
+
 ENV["RACK_ENV"] = "test"
 ENV["REDIS_URL"] = "redis://rediswoohoo:abc123@example.com:12345/"
 

--- a/spec/support/strip_heredoc.rb
+++ b/spec/support/strip_heredoc.rb
@@ -1,0 +1,8 @@
+# Stolen from ActiveSupport,
+# `activesupport/lib/active_support/core_ext/string/strip.rb`
+class String
+  def strip_heredoc
+    indent = scan(/^[ \t]*(?=\S)/).min.size
+    gsub(/^[ \t]{#{indent}}/, "")
+  end
+end


### PR DESCRIPTION
This removes the attempts to create OO in `ScssReviewJob` with its
`private_class_method`'s.

Changes:

- Extract all strings into constants, and freeze them. For memory
  purposes.