### PR TITLE
Add link to the SCSS configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 SCSS review service for Hound. Backed by [SCSS-Lint](https://github.com/brigade/scss-lint).
 
+For more information on the SCSS configuration options, please refer to the [scss-lint documentation](https://github.com/brigade/scss-lint/blob/master/lib/scss_lint/linter/README.md).
+
 The service consists of a simple job class that uses Redis as a queue to
 coordinate work with Hound.
 


### PR DESCRIPTION
In response to the https://github.com/thoughtbot/hound/issues/736 and
https://github.com/thoughtbot/hound/pull/1046#issuecomment-176995767

Providing a link to the description of all the specific options in the
SCSS config should make it easier to understand what each specified
option does.